### PR TITLE
Fix typo: frequency MSB not sent correctly

### DIFF
--- a/src/WEMOS_Motor.cpp
+++ b/src/WEMOS_Motor.cpp
@@ -57,7 +57,7 @@ freq:
 void Motor::setfreq(uint32_t freq)
 {
 	Wire.beginTransmission(_address);
-	Wire.write(((byte)(freq >> 16)) & (byte)0x0f);
+	Wire.write(((byte)(freq >> 24)) & (byte)0x0f);
 	Wire.write((byte)(freq >> 16));
 	Wire.write((byte)(freq >> 8));
 	Wire.write((byte)freq);


### PR DESCRIPTION
See the relevant code in the [firmware](https://github.com/wemos/Motor_Shield_Firmware/blob/master/Src/user_i2c.c#L34), which shifts left by 24 bits